### PR TITLE
Logsmanagement compile switch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -624,7 +624,8 @@ MONGODB_BACKEND_FILES = \
     backends/mongodb/mongodb.h \
     $(NULL)
 
-LOGSMANAGEMENT_PLUGIN_FILES = \
+if ENABLE_LOGSMANAGEMENT
+LOGSMANAGEMENT_FILES = \
     logsmanagement/circular_buffer.c \
     logsmanagement/circular_buffer.h \
     logsmanagement/compression.c \
@@ -640,6 +641,7 @@ LOGSMANAGEMENT_PLUGIN_FILES = \
     logsmanagement/query_test.c \
     logsmanagement/query_test.h \
     $(NULL)
+endif
 
 DAEMON_FILES = \
     daemon/buildinfo.c \
@@ -680,7 +682,7 @@ NETDATA_FILES = \
     $(PARSER_FILES) \
     $(ACLK_FILES) \
     $(SPAWN_PLUGIN_FILES) \
-    $(LOGSMANAGEMENT_PLUGIN_FILES) \
+    $(LOGSMANAGEMENT_FILES) \
     $(NULL)
 
 if FREEBSD

--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,20 @@ AC_ARG_WITH(
     ],
     [with_bundled_lws="no"]
 )
+AC_ARG_ENABLE(
+    [logsmanagement],
+    [AS_HELP_STRING([--enable-logsmanagement],
+                    [Enable logsmanagement @<:@default disabled@:>@])],
+    ,
+    [enable_logsmanagement="detect"]
+)
+
+if test "${enable_logsmanagement}" = "yes"; then
+    AC_DEFINE([ENABLE_LOGSMANAGEMENT], [1], [enable logs management functionality])
+fi
+
+AC_MSG_RESULT([${enable_logsmanagement}])
+AM_CONDITIONAL([ENABLE_LOGSMANAGEMENT], [test "${enable_logsmanagement}" = "yes"])
 
 # -----------------------------------------------------------------------------
 # Enforce building with C99, bail early if we can't.
@@ -738,7 +752,6 @@ else
 fi
 AC_MSG_RESULT([${enable_plugin_apps}])
 AM_CONDITIONAL([ENABLE_PLUGIN_APPS], [test "${enable_plugin_apps}" = "yes"])
-
 
 # -----------------------------------------------------------------------------
 # freeipmi.plugin - libipmimonitoring

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -6,6 +6,11 @@
 int netdata_zero_metrics_enabled;
 int netdata_anonymous_statistics_enabled;
 
+//should go in common.h or libnetdata.h when ready
+#ifdef ENABLE_LOGSMANAGEMENT
+extern void logsmanagement_main();
+#endif
+
 struct config netdata_config = {
         .first_section = NULL,
         .last_section = NULL,
@@ -1487,6 +1492,12 @@ int main(int argc, char **argv) {
         }
         else debug(D_SYSTEM, "Not starting thread %s.", st->name);
     }
+
+    // ------------------------------------------------------------------------
+    // Start logsmanagement
+#ifdef ENABLE_LOGSMANAGEMENT
+    logsmanagement_main();
+#endif
 
     // ------------------------------------------------------------------------
     // Initialize netdata agent command serving from cli and signals

--- a/logsmanagement/logsmanagement.c
+++ b/logsmanagement/logsmanagement.c
@@ -589,7 +589,8 @@ static int monitor_log_file_init(const char *filename) {
  * After any initialisation routines, the default uv_loop_t is executed indefinitely. 
  * @todo Any cleanup required on program exit? 
  */
-int logsmanagement_main(int argc, const char *argv[]) {
+//int logsmanagement_main(int argc, const char *argv[]) {
+void logsmanagement_main(void) {
     //int rc = 0;
 
     // Static asserts
@@ -611,13 +612,13 @@ int logsmanagement_main(int argc, const char *argv[]) {
     uv_thread_create(&fs_events_reenable_thread_id, fs_events_reenable_thread, NULL);
 
     // Read files to monitor from arguments if they exist.
-    if (argc > 1) {
-        fprintf_log(INFO, stderr, "Arguments found - to be used as log sources\n");
-        for (int arg_off = 1; arg_off < argc; arg_off++) {
-            fprintf_log(INFO, stderr, "Arg %d: %s\n", arg_off, argv[arg_off]);
-            monitor_log_file_init(argv[arg_off]);
-        }
-    } else {
+    /* if (argc > 1) { */
+    /*     fprintf_log(INFO, stderr, "Arguments found - to be used as log sources\n"); */
+    /*     for (int arg_off = 1; arg_off < argc; arg_off++) { */
+    /*         fprintf_log(INFO, stderr, "Arg %d: %s\n", arg_off, argv[arg_off]); */
+    /*         monitor_log_file_init(argv[arg_off]); */
+    /*     } */
+    /* } else { */
         fprintf_log(INFO, stderr, "Arguments not found - using hard-coded log sources\n");
         monitor_log_file_init(SIMULATED_APACHE_LOG_PATH);
         monitor_log_file_init(SIMULATED_PHP_LOG_PATH);
@@ -627,7 +628,7 @@ int logsmanagement_main(int argc, const char *argv[]) {
         // monitor_log_file_init(DAEMON_LOG_PATH);
         monitor_log_file_init(APACHE_LOG_PATH);
         monitor_log_file_init(APACHE_ERROR_LOG_PATH);
-    }
+    /* } */
 
     fprintf_log(INFO, stderr,
                 "File monitoring setup completed. Running db_init().\n" LOG_SEPARATOR);

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -219,6 +219,7 @@ USAGE: ${PROGRAM} [options]
   --disable-plugin-freeipmi
   --disable-https            Explicitly disable TLS support
   --disable-dbengine         Explicitly disable DB engine support
+  --enable-logsmanagement    Enable the logs management plugin. Default is disabled.
   --enable-plugin-nfacct     Enable nfacct plugin. Default: enable it when libmnl and libnetfilter_acct are available.
   --disable-plugin-nfacct
   --enable-plugin-xenstat    Enable the xenstat plugin. Default: enable it when libxenstat and libyajl are available
@@ -302,6 +303,7 @@ while [ -n "${1}" ]; do
       NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-dbengine/} --disable-dbengine"
       NETDATA_DISABLE_DBENGINE=1
       ;;
+    "--enable-logsmanagement") NETDATA_LOGSMANAGEMENT=1 NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-logsmanagement/} --enable-logsmanagement" ;;
     "--enable-plugin-nfacct") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-nfacct/} --enable-plugin-nfacct" ;;
     "--disable-plugin-nfacct") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--disable-plugin-nfacct/} --disable-plugin-nfacct" ;;
     "--enable-plugin-xenstat") NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-plugin-xenstat/} --enable-plugin-xenstat" ;;


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Add a switch to enable logsmanagement at compile time. Default is disable. 
Start logsmanagement_main from daemon/main.c

##### Component Name

##### Test Plan

Try compiling using the `netdata-installer.sh` using the switch `--enable-logsmanagement`.

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
